### PR TITLE
Switch long-running render command to async API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ testing = [
     "mypy",
     "pre-commit",
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-socket",
     "ruff",

--- a/tests/__snapshots__/test_util.ambr
+++ b/tests/__snapshots__/test_util.ambr
@@ -11,3 +11,21 @@
     ),
   ])
 # ---
+# name: test_project_render
+  dict({
+    'get': _CallList([
+      _Call(
+        '',
+        tuple(
+          'http://localhost:2307/_/42230',
+        ),
+        dict({
+        }),
+      ),
+    ]),
+    'post': _CallList([
+    ]),
+    'put': _CallList([
+    ]),
+  })
+# ---

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,6 +7,8 @@ import music.util
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from .conftest import RequestsMocks
+
 
 @mock.patch("reapy.core.Project.__init__")
 def test_project_reaper_not_running(core_project: mock.Mock) -> None:
@@ -47,3 +49,13 @@ def test_project_open(
     some_path = tmp_path / "path" / "to" / "some project"
     music.util.ExtendedProject.get_or_open(some_path)
     assert open_project.mock_calls == snapshot
+
+
+@pytest.mark.asyncio
+@mock.patch("reapy.core.Project.__init__")
+async def test_project_render(
+    open_project: mock.Mock, requests_mocks: RequestsMocks, snapshot: SnapshotAssertion
+) -> None:
+    """Test invoking Reaper to render a project."""
+    await music.util.ExtendedProject().render()
+    assert requests_mocks.mock_calls == snapshot


### PR DESCRIPTION
After past efforts to switch to the `async` keyword throughout this library, this change _finally_ provides a speed benefit, when performing a render and asynchronously moving onto something else, like upload.

# TODO

- [x] Get Reaper HTTP port from reapy
- [ ] ~~Fix multiple upload spinners overlapping each other~~
- [x] **AND/OR** Limit concurrent uploads to 1 (they don't give a speed benefit on my home internet)
- [ ] ~~Fix render/upload spinners overlapping each other~~ (this isn't great behavior, but gonna save the fix for later)
- [x] Manually confirm parallel, non-blocking work with upload progress bar
    - Reaper UI has a progress bar I can monitor separately. It would be great to integrate that into this project. But one thing at a time.
