### PR TITLE
Add option to render stems

### DIFF
--- a/src/music/render/command.py
+++ b/src/music/render/command.py
@@ -40,7 +40,7 @@ _CONSOLE_WIDTH: int | None = None
     default=None,
     flag_value=SongVersion.MAIN,
     help=(
-        "Whether to include the main version. Defaults to including all versions,"
+        "Whether to include the main version. Defaults to including main, instrumental, and a cappella versions,"
         ' unless one of the "--include-*" flags is set.'
     ),
     type=SongVersion,
@@ -51,7 +51,7 @@ _CONSOLE_WIDTH: int | None = None
     flag_value=SongVersion.INSTRUMENTAL,
     help=(
         "Whether to include the instrumental version. This version is skipped"
-        " if no vocals exist. Defaults to including all versions,"
+        " if no vocals exist. Defaults to including main, instrumental, and a cappella versions,"
         ' unless one of the "--include-*" flags is set.'
     ),
     type=SongVersion,
@@ -62,7 +62,7 @@ _CONSOLE_WIDTH: int | None = None
     flag_value=SongVersion.ACAPPELLA,
     help=(
         "Whether to include the a cappella version. This version is skipped if"
-        " no vocals exist. Defaults to including all versions, unless"
+        " no vocals exist. Defaults to including main, instrumental, and a cappella versions, unless"
         ' one of the "--include-*" flags is set.'
     ),
     type=SongVersion,
@@ -72,7 +72,7 @@ _CONSOLE_WIDTH: int | None = None
     default=None,
     flag_value=SongVersion.STEMS,
     help=(
-        "Whether to include the mix stems. Defaults to including all versions, unless"
+        "Whether to include the mix stems. Defaults to including main, instrumental, and a cappella versions, unless"
         ' one of the "--include-*" flags is set.'
     ),
     type=SongVersion,
@@ -156,7 +156,7 @@ async def main(
             include_stems,
         )
         if version
-    } or list(SongVersion)
+    } or (SongVersion.MAIN, SongVersion.INSTRUMENTAL, SongVersion.ACAPPELLA)
 
     renders = []
 

--- a/src/music/render/process.py
+++ b/src/music/render/process.py
@@ -258,7 +258,11 @@ async def render_version(
         reapy.reascript_api.SNM_SetIntConfigVar("runallonstop", prev_runallonstop)  # type: ignore[attr-defined]
 
     out_fil = version.path_for_project_dir(Path(project.path))
-    tmp_fil = out_fil.with_stem(in_name)
+    if version == SongVersion.STEMS:
+        tmp_fil = out_fil.parent / in_name
+    else:
+        tmp_fil = out_fil.with_stem(in_name)
+
     rm_rf(out_fil)
     shutil.move(tmp_fil, out_fil)
 

--- a/src/music/render/process.py
+++ b/src/music/render/process.py
@@ -120,7 +120,7 @@ def _find_stems(project: reapy.core.Project) -> list[reapy.core.Track]:
     return [
         track
         for track in project.tracks
-        if not track.is_muted and bool(track.items) or bool(len(track.fxs))
+        if not track.is_muted and (bool(track.items) or bool(len(track.fxs)))
     ]
 
 

--- a/src/music/render/process.py
+++ b/src/music/render/process.py
@@ -445,9 +445,11 @@ class Process:
         name = version.name_for_project_dir(Path(project.path))
         out_fil = version.path_for_project_dir(Path(project.path))
 
-        before_stats = summary_stats_for_file(out_fil) if out_fil.exists() else {}
+        before_stats = summary_stats_for_file(out_fil) if out_fil.is_file() else {}
         out = await render()
-        after_stats = summary_stats_for_file(out_fil, verbose)
+        after_stats = (
+            summary_stats_for_file(out_fil, verbose) if out_fil.is_file() else {}
+        )
 
         self.console.print(f"[b default]{name}[/b default]")
         self.console.print(f"[default dim italic]{out.fil}[/default dim italic]")

--- a/src/music/render/process.py
+++ b/src/music/render/process.py
@@ -27,6 +27,7 @@ from music.util import (
     ExtendedProject,
     SongVersion,
     recurse_property,
+    rm_rf,
     set_param_value,
 )
 
@@ -257,7 +258,9 @@ async def render_version(
         reapy.reascript_api.SNM_SetIntConfigVar("runallonstop", prev_runallonstop)  # type: ignore[attr-defined]
 
     out_fil = version.path_for_project_dir(Path(project.path))
-    shutil.move(out_fil.with_stem(in_name), out_fil)
+    tmp_fil = out_fil.with_stem(in_name)
+    rm_rf(out_fil)
+    shutil.move(tmp_fil, out_fil)
 
     return RenderResult(out_fil, datetime.timedelta(seconds=time_end - time_start))
 

--- a/src/music/stat/command.py
+++ b/src/music/stat/command.py
@@ -43,5 +43,5 @@ def _files_for_project_dir(project_dir: Path) -> list[Path]:
     return [
         fil
         for version in SongVersion
-        if (fil := version.path_for_project_dir(project_dir)) and fil.exists()
+        if (fil := version.path_for_project_dir(project_dir)) and fil.is_file()
     ]

--- a/src/music/upload/command.py
+++ b/src/music/upload/command.py
@@ -25,7 +25,7 @@ from .process import Process as UploadProcess
     default=None,
     flag_value=SongVersion.MAIN,
     help=(
-        "Whether to include the main version. Defaults to including all versions,"
+        "Whether to include the main version. Defaults to including all uploadable versions,"
         ' unless one of the "--include-*" flags is set.'
     ),
     type=SongVersion,
@@ -36,7 +36,7 @@ from .process import Process as UploadProcess
     flag_value=SongVersion.INSTRUMENTAL,
     help=(
         "Whether to include the instrumental version."
-        " Defaults to including all versions,"
+        " Defaults to including all uploadable versions,"
         ' unless one of the "--include-*" flags is set.'
     ),
     type=SongVersion,
@@ -47,7 +47,7 @@ from .process import Process as UploadProcess
     flag_value=SongVersion.ACAPPELLA,
     help=(
         "Whether to include the a cappella version."
-        " Defaults to including all versions, unless"
+        " Defaults to including all uploadable versions, unless"
         ' one of the "--include-*" flags is set.'
     ),
     type=SongVersion,
@@ -83,7 +83,7 @@ async def main(
         version
         for version in (include_main, include_instrumental, include_acappella)
         if version
-    } or list(SongVersion)
+    } or (SongVersion.MAIN, SongVersion.INSTRUMENTAL, SongVersion.ACAPPELLA)
 
     files = [
         fil

--- a/src/music/upload/command.py
+++ b/src/music/upload/command.py
@@ -89,7 +89,7 @@ async def main(
         fil
         for project_dir in project_dirs
         for version in versions
-        if (fil := version.path_for_project_dir(project_dir)) and fil.exists()
+        if (fil := version.path_for_project_dir(project_dir)) and fil.is_file()
     ]
 
     if not files:

--- a/src/music/util.py
+++ b/src/music/util.py
@@ -3,6 +3,8 @@
 import asyncio
 import enum
 import json
+import os
+import shutil
 import warnings
 from collections.abc import Callable, Iterator
 from functools import wraps
@@ -151,6 +153,14 @@ def recurse_property(prop: str, obj: T | None) -> Iterator[T]:
     while obj is not None:
         yield obj
         obj = getattr(obj, prop, None)
+
+
+def rm_rf(path: Path) -> None:
+    """Delete a file or directory recursively, if it exists, similarly to `rm -rf <PATH>`."""
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path)
+    elif os.path.exists(path):
+        os.remove(path)
 
 
 # @contextlib.contextmanager

--- a/src/music/util.py
+++ b/src/music/util.py
@@ -163,11 +163,6 @@ def rm_rf(path: Path) -> None:
         os.remove(path)
 
 
-# @contextlib.contextmanager
-# def with_set_value(f: Callable[[T], T], old_value: T = ...) -> Iterator[None]:
-#     pass
-
-
 def set_param_value(param: reapy.core.FXParam, value: float) -> None:
     """Set a parameter's value.
 

--- a/src/music/util.py
+++ b/src/music/util.py
@@ -27,6 +27,7 @@ class SongVersion(enum.Enum):
     MAIN = enum.auto()
     INSTRUMENTAL = enum.auto()
     ACAPPELLA = enum.auto()
+    STEMS = enum.auto()
 
     def name_for_project_dir(self, project_dir: Path) -> str:
         """Name of the project for the given song version."""
@@ -37,12 +38,27 @@ class SongVersion(enum.Enum):
             return f"{project_name} (Instrumental)"
         elif self is SongVersion.ACAPPELLA:
             return f"{project_name} (A Cappella)"
+        elif self is SongVersion.STEMS:
+            return f"{project_name} (Stems)"
         else:  # pragma: no cover
             assert_exhaustiveness(self)
 
     def path_for_project_dir(self, project_dir: Path) -> Path:
         """Path of the rendered file for the given song version."""
-        return project_dir / f"{self.name_for_project_dir(project_dir)}.wav"
+        basename = project_dir / self.name_for_project_dir(project_dir)
+        if self is SongVersion.STEMS:
+            return basename
+
+        return basename.with_suffix(".wav")
+
+    @property
+    def pattern(self) -> list[Path]:
+        """Reaper directory render pattern for the given song version, if any."""
+        if self is SongVersion.STEMS:
+            # Roughly create a directory tree matching the tracks and folders in the Reaper project.
+            return [Path("$folders $tracknumber - $track")]
+
+        return []
 
 
 class ExtendedProject(reapy.core.Project):
@@ -134,6 +150,11 @@ def recurse_property(prop: str, obj: T | None) -> Iterator[T]:
     while obj is not None:
         yield obj
         obj = getattr(obj, prop, None)
+
+
+# @contextlib.contextmanager
+# def with_set_value(f: Callable[[T], T], old_value: T = ...) -> Iterator[None]:
+#     pass
 
 
 def set_param_value(param: reapy.core.FXParam, value: float) -> None:

--- a/src/music/util.py
+++ b/src/music/util.py
@@ -47,11 +47,11 @@ class SongVersion(enum.Enum):
 
     def path_for_project_dir(self, project_dir: Path) -> Path:
         """Path of the rendered file for the given song version."""
-        basename = project_dir / self.name_for_project_dir(project_dir)
+        path = project_dir / self.name_for_project_dir(project_dir)
         if self is SongVersion.STEMS:
-            return basename
+            return path
 
-        return basename.with_suffix(".wav")
+        return Path(f"{path}.wav")
 
     @property
     def pattern(self) -> list[Path]:

--- a/src/music/util.py
+++ b/src/music/util.py
@@ -113,6 +113,7 @@ class ExtendedProject(reapy.core.Project):
         async with aiohttp.ClientSession() as client:
             resp = await client.get(
                 f"http://localhost:{port}/_/{RENDER_CMD_ID}",
+                timeout=aiohttp.ClientTimeout(total=60 * 30),
             )
             resp.raise_for_status()
 

--- a/tests/__snapshots__/test_render.ambr
+++ b/tests/__snapshots__/test_render.ambr
@@ -1310,7 +1310,7 @@
         list([
           'ffprobe',
           '-i',
-          'TMP_PATH_HERE',
+          'TMP_PATH_HERE/foo.wav',
           '-show_entries',
           'format=duration',
         ]),

--- a/tests/__snapshots__/test_render.ambr
+++ b/tests/__snapshots__/test_render.ambr
@@ -33,9 +33,19 @@
              ╵        ╵        
    Rendered in 0:00:00, a infx 
              speedup           
+  
+  Stub Song Title (feat. Stub Artist) (Stems)
+  TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (Stems)
+     ╷        ╷        
+     │ Before │ After  
+  ╶──┼────────┼───────╴
+     ╵        ╵        
+  Rendered in 0:00:00, 
+     a infx speedup    
     Rendering "Stub Song Title (feat. Stub Artist)"                0:00:00
     Rendering "Stub Song Title (feat. Stub Artist) (Instrumental)" 0:00:00
     Rendering "Stub Song Title (feat. Stub Artist) (A Cappella)"   0:00:00
+    Rendering "Stub Song Title (feat. Stub Artist) (Stems)"        0:00:00
   
   '''
 # ---
@@ -134,6 +144,57 @@
       tuple(
         'RENDER_PATTERN',
         '$project',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+        144,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'Stub Song Title (feat. Stub Artist) (Stems).tmp/$folders $tracknumber - $track',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'render',
+      tuple(
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        '$project',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+        'ASYNC_ITERABLE_HERE',
       ),
       dict({
       }),
@@ -505,6 +566,15 @@
              ╵        ╵        
    Rendered in 0:00:00, a infx 
              speedup           
+  
+  Stub Song Title (feat. Stub Artist) (Stems)
+  TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (Stems)
+     ╷        ╷        
+     │ Before │ After  
+  ╶──┼────────┼───────╴
+     ╵        ╵        
+  Rendered in 0:00:00, 
+     a infx speedup    
   Stub Song Title (feat. Stub Artist)
   TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist).wav
              ╷        ╷        
@@ -537,12 +607,23 @@
              ╵        ╵        
    Rendered in 0:00:00, a infx 
              speedup           
+  
+  Stub Song Title (feat. Stub Artist) (Stems)
+  TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (Stems)
+     ╷        ╷        
+     │ Before │ After  
+  ╶──┼────────┼───────╴
+     ╵        ╵        
+  Rendered in 0:00:00, 
+     a infx speedup    
     Rendering "Stub Song Title (feat. Stub Artist)"                0:00:00
     Rendering "Stub Song Title (feat. Stub Artist) (Instrumental)" 0:00:00
     Rendering "Stub Song Title (feat. Stub Artist) (A Cappella)"   0:00:00
+    Rendering "Stub Song Title (feat. Stub Artist) (Stems)"        0:00:00
     Rendering "Stub Song Title (feat. Stub Artist)"                0:00:00
     Rendering "Stub Song Title (feat. Stub Artist) (Instrumental)" 0:00:00
     Rendering "Stub Song Title (feat. Stub Artist) (A Cappella)"   0:00:00
+    Rendering "Stub Song Title (feat. Stub Artist) (Stems)"        0:00:00
   
   '''
 # ---
@@ -641,6 +722,57 @@
       tuple(
         'RENDER_PATTERN',
         '$project',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+        144,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'Stub Song Title (feat. Stub Artist) (Stems).tmp/$folders $tracknumber - $track',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'render',
+      tuple(
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        '$project',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+        'ASYNC_ITERABLE_HERE',
       ),
       dict({
       }),
@@ -745,6 +877,57 @@
       tuple(
         'RENDER_PATTERN',
         '$project',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+        144,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'Stub Song Title (feat. Stub Artist) (Stems).tmp/$folders $tracknumber - $track',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'render',
+      tuple(
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        '$project',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_SETTINGS',
+        'ASYNC_ITERABLE_HERE',
       ),
       dict({
       }),

--- a/tests/__snapshots__/test_util.ambr
+++ b/tests/__snapshots__/test_util.ambr
@@ -20,6 +20,7 @@
           'http://localhost:2307/_/42230',
         ),
         dict({
+          'timeout': ClientTimeout(total=1800, connect=None, sock_read=None, sock_connect=None, ceil_threshold=5),
         }),
       ),
     ]),

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -93,7 +93,9 @@ def render_mocks(
                 render_patterns.append(value)
 
         async def render_fake_file() -> None:
-            (Path(project.path) / f"{render_patterns[-1]}.wav").touch()
+            path = Path(project.path) / f"{render_patterns[-1]}.wav"
+            path.parent.mkdir(exist_ok=True, parents=True)
+            path.touch()
 
         path = tmp_path / "Stub Song Title (feat. Stub Artist)"
         path.mkdir()
@@ -266,7 +268,12 @@ def test_main_all_versions(
     """Test main with all versions."""
     result = CliRunner(mix_stderr=False).invoke(
         render,
-        ["--include-main", "--include-instrumental", "--include-acappella"],
+        [
+            "--include-main",
+            "--include-instrumental",
+            "--include-acappella",
+            "--include-stems",
+        ],
         catch_exceptions=False,
     )
 
@@ -299,6 +306,7 @@ def test_main_filenames_all_versions(
             "--include-main",
             "--include-instrumental",
             "--include-acappella",
+            "--include-stems",
             *[str(path.resolve()) for path in some_paths],
         ],
         catch_exceptions=False,

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -175,8 +175,11 @@ def test_render_result_render_speedup(
     [/FORMAT]
     """
 
-    obj1 = RenderResult(tmp_path, datetime.timedelta(seconds=4.5))
-    obj2 = RenderResult(tmp_path, datetime.timedelta(seconds=0.1))
+    some_file = tmp_path / "foo.wav"
+    some_file.touch()
+
+    obj1 = RenderResult(some_file, datetime.timedelta(seconds=4.5))
+    obj2 = RenderResult(some_file, datetime.timedelta(seconds=0.1))
 
     assert obj1.render_speedup == 5.75
     assert obj2.render_speedup == math.inf

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -14,6 +14,8 @@ from syrupy.assertion import SnapshotAssertion
 
 from .conftest import RequestsMocks
 
+ST_MODE_IS_FILE = 33188
+
 
 @pytest.fixture
 def some_paths(tmp_path: Path) -> list[Path]:
@@ -83,7 +85,8 @@ def test_main_tracks_newer(
         """
         if self in some_paths:
             return mock.Mock(
-                st_mtime=datetime.datetime.fromisoformat(old_timestamp).timestamp()
+                st_mode=ST_MODE_IS_FILE,
+                st_mtime=datetime.datetime.fromisoformat(old_timestamp).timestamp(),
             )
 
         return original_stat(self, *args, **kwargs)


### PR DESCRIPTION
The stems are a faithful reproduction of tracks from my music projects individually rendered, so collaborators can import them into their DAW, without needing my exact DAW, settings, and plugins. 

Usually, if you mix together all the stems and apply master FX, you get the master mix (separately available via the existing `--include-main` flag). There are caveats with my Reaper projects, because I use Reaper's track folders with FX, so they repeat some rendered audio.

Reaper has a preset for stems during render, but there isn't a one-size-fits-all method. Some DAW users have projects with complex routing and track nesting. The approach of track selection and picking render settings in this patch are generalized for stems for my personal project conventions.

# Changes

* Add option `--include-stems` to render stems
* Match the track folder structure in the Reaper project to what goes on disk.
* Find tracks that make sense as stems to pass to another collaborator.
  * Some are muted or just for grouping, and do not contribute to the final mix.
* Disable master track FX.
  * They would influence individual stems.
  * The master mix is already handled by `--include-main`.
* Handle folder vs. file render output.
* Bump Reaper HTTP request timeout, to allow all stems to complete.
* Don't render stems by default.
  * It's a time intensive and experimental command.
* Don't upload stems.
  * Multiple files do not make sense for SoundCloud songs.

# Test Plan

* [x] Add option to existing CLI unit test cases

# Future Work

* Display summary stats for the new song version better than an empty table
  * The existing stats make most sense for a single audio file