### PR TITLE
Add render `--dry-run` flag

### DIFF
--- a/src/music/render/result.py
+++ b/src/music/render/result.py
@@ -46,11 +46,19 @@ class RenderResult(ExistingRenderResult):
         version: SongVersion,
         fil: Path,
         render_delta: datetime.timedelta,
+        *,
+        eager: bool = False,
     ):
         """Override. Initialize."""
         super().__init__(project, version)
         self.fil = fil
         self.render_delta = datetime.timedelta(seconds=round(render_delta.seconds))
+
+        if eager:
+            # Trigger computation eagerly. For example, the input file might be
+            # temporary and not exist later.
+            self.duration_delta  # noqa: B018
+            self.summary_stats  # noqa: B018
 
     @cached_property
     def duration_delta(self) -> datetime.timedelta:

--- a/tests/render/__snapshots__/test_render.ambr
+++ b/tests/render/__snapshots__/test_render.ambr
@@ -1267,6 +1267,494 @@
     ),
   ])
 # ---
+# name: test_main_default_versions_dry_run
+  '''
+  Stub Song Title (feat. Stub Artist)
+  TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist).tmp.wav
+             ╷        ╷        
+             │ Before │ After  
+  ╶──────────┼────────┼───────╴
+    duration │        │ 1.0    
+    size     │        │ 42.0   
+             ╵        ╵        
+   Rendered in 0:00:00, a infx 
+             speedup           
+  
+  Stub Song Title (feat. Stub Artist) (Instrumental)
+  TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (Instrumental).tmp.wav
+             ╷        ╷        
+             │ Before │ After  
+  ╶──────────┼────────┼───────╴
+    duration │        │ 250.1  
+    size     │        │ 1024   
+             ╵        ╵        
+   Rendered in 0:00:00, a infx 
+             speedup           
+  
+  Stub Song Title (feat. Stub Artist) (A Cappella)
+  TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (A Cappella).tmp.wav
+             ╷        ╷        
+             │ Before │ After  
+  ╶──────────┼────────┼───────╴
+    duration │        │ 1.0    
+    size     │        │ 42.0   
+             ╵        ╵        
+   Rendered in 0:00:00, a infx 
+             speedup           
+  ✓ Rendering "Stub Song Title (feat. Stub Artist)"                0:00:00
+  ✓ Rendering "Stub Song Title (feat. Stub Artist) (Instrumental)" 0:00:00
+  ✓ Rendering "Stub Song Title (feat. Stub Artist) (A Cappella)"   0:00:00
+  
+  '''
+# ---
+# name: test_main_default_versions_dry_run.1
+  _CallList([
+    _Call(
+      'metadata.get',
+      tuple(
+        'vocal-loudness-worth',
+        2.0,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'metadata.get().__float__',
+      tuple(
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+        0,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+        1.0,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+        19.5,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_string',
+      tuple(
+        'RENDER_PATTERN',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'Stub Song Title (feat. Stub Artist).tmp',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'render',
+      tuple(
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+        0,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+        1.0,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+        19.5,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_string',
+      tuple(
+        'RENDER_PATTERN',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'Stub Song Title (feat. Stub Artist) (Instrumental).tmp',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'render',
+      tuple(
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+        0,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+        1.0,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+        19.5,
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'get_info_string',
+      tuple(
+        'RENDER_PATTERN',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'Stub Song Title (feat. Stub Artist) (A Cappella).tmp',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'render',
+      tuple(
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_string',
+      tuple(
+        'RENDER_PATTERN',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_ENDPOS',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_STARTPOS',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'set_info_value',
+      tuple(
+        'RENDER_BOUNDSFLAG',
+        'ASYNC_ITERABLE_HERE',
+      ),
+      dict({
+      }),
+    ),
+    _Call(
+      'save',
+      tuple(
+      ),
+      dict({
+      }),
+    ),
+  ])
+# ---
+# name: test_main_default_versions_dry_run.2
+  _CallList([
+    _Call(
+      '',
+      tuple(
+        list([
+          'ffmpeg',
+          '-i',
+          'TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist).tmp.wav',
+          '-filter:a',
+          'volumedetect,ebur128=framelog=verbose',
+          '-hide_banner',
+          '-nostats',
+          '-f',
+          'null',
+          '/dev/null',
+        ]),
+      ),
+      dict({
+        'check': True,
+        'stderr': -1,
+        'text': True,
+      }),
+    ),
+    _Call(
+      '',
+      tuple(
+        list([
+          'ffmpeg',
+          '-i',
+          'TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (Instrumental).tmp.wav',
+          '-filter:a',
+          'volumedetect,ebur128=framelog=verbose',
+          '-hide_banner',
+          '-nostats',
+          '-f',
+          'null',
+          '/dev/null',
+        ]),
+      ),
+      dict({
+        'check': True,
+        'stderr': -1,
+        'text': True,
+      }),
+    ),
+    _Call(
+      '',
+      tuple(
+        list([
+          'ffmpeg',
+          '-i',
+          'TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (A Cappella).tmp.wav',
+          '-filter:a',
+          'volumedetect,ebur128=framelog=verbose',
+          '-hide_banner',
+          '-nostats',
+          '-f',
+          'null',
+          '/dev/null',
+        ]),
+      ),
+      dict({
+        'check': True,
+        'stderr': -1,
+        'text': True,
+      }),
+    ),
+    _Call(
+      '',
+      tuple(
+        list([
+          'ffmpeg',
+          '-i',
+          'TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (A Cappella).tmp.wav',
+          '-filter:a',
+          'areverse,atrim=start=0.2,silenceremove=start_periods=1:start_silence=3.0:start_threshold=0.02,areverse,atrim=start=0.2,silenceremove=start_periods=1:start_silence=1.0:start_threshold=0.02',
+          'TMP_PATH_HERE/Stub Song Title (feat. Stub Artist)/Stub Song Title (feat. Stub Artist) (A Cappella).tmp.wav.tmp.wav',
+        ]),
+      ),
+      dict({
+        'check': True,
+        'stderr': -1,
+        'text': True,
+      }),
+    ),
+  ])
+# ---
 # name: test_main_filenames_all_versions
   '''
   Stub Song Title (feat. Stub Artist)

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -112,6 +112,25 @@ def test_main_default_versions(
     assert subprocess_with_output.mock_calls == snapshot
 
 
+def test_main_default_versions_dry_run(
+    render_mocks: RenderMocks,
+    snapshot: SnapshotAssertion,
+    subprocess_with_output: mock.Mock,
+) -> None:
+    """Test main dry run, with default versions."""
+    result = CliRunner(mix_stderr=False).invoke(
+        render, ["--dry-run"], catch_exceptions=False
+    )
+
+    assert not result.exception
+    assert result.stdout == snapshot
+    assert not result.stderr
+
+    assert render_mocks.project.mock_calls == snapshot
+    assert subprocess_with_output.mock_calls
+    assert subprocess_with_output.mock_calls == snapshot
+
+
 def test_main_instrumental_versions_only_main_vocals(
     render_mocks: RenderMocks,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
Useful for testing song changes or CLI changes, without creating noise on disk or no-op uploads.

# Changes

* Thread new kwarg to all render helper functions
* During dry run,
  * do not leave changed files on disk, do not upload
  * eagerly compute result stats, before temp file is deleted

# Test Plan

* Add test case, snapshot only temp files (e.g. "Stub Song Title.tmp.wav" not "Stub Song Title.wav")