### PR TITLE
Unify skipped/failed upload indicators with successful upload indicators

### DIFF
--- a/src/music/render/process.py
+++ b/src/music/render/process.py
@@ -191,7 +191,7 @@ class Process:
         """Initialize."""
         self.console = console
         self.console_err = console_err
-        self.progress = Progress()
+        self.progress = Progress(self.console)
 
     async def process(  # noqa: C901
         self,

--- a/src/music/upload/command.py
+++ b/src/music/upload/command.py
@@ -1,6 +1,7 @@
 """Upload command."""
 
 import email
+import sys
 from pathlib import Path
 
 import aiohttp
@@ -138,4 +139,8 @@ async def main(
     process = UploadProcess(console)
     with rich.live.Live(process.progress, console=console, refresh_per_second=10):
         async with aiohttp.ClientSession() as client:
-            await process.process(client, oauth_token, parsed_additional_headers, files)
+            status = await process.process(
+                client, oauth_token, parsed_additional_headers, files
+            )
+
+    sys.exit(status)

--- a/src/music/upload/command.py
+++ b/src/music/upload/command.py
@@ -1,7 +1,6 @@
 """Upload command."""
 
 import email
-import sys
 from pathlib import Path
 
 import aiohttp
@@ -143,4 +142,5 @@ async def main(
                 client, oauth_token, parsed_additional_headers, files
             )
 
-    sys.exit(status)
+    if status:
+        raise click.exceptions.Exit(status)

--- a/src/music/upload/process.py
+++ b/src/music/upload/process.py
@@ -156,7 +156,7 @@ class Process:
             await self._upload(client, task, fil, upload)
 
             task = self.progress_transcode.add_task(
-                f'[bold green]Transcoding "{fil.name}"', total=1
+                f'Transcoding "{fil.name}"', total=1
             )
 
             await self._transcode(client, headers, upload)

--- a/tests/__snapshots__/test_upload.ambr
+++ b/tests/__snapshots__/test_upload.ambr
@@ -207,8 +207,10 @@
   tuple(
     None,
     '''
-      Skipping already uploaded "some project.wav"
-      Skipping already uploaded "another project.wav"
+      ⚠ Uploading "some project.wav" (already uploaded)    0:00:00           0.0/1.2  
+                                                                             MB       
+      ⚠ Uploading "another project.wav" (already uploaded) 0:00:00           0.0/1.2  
+                                                                             MB       
   
     ''',
     '',
@@ -242,7 +244,15 @@
 # ---
 # name: test_main_tracks_not_found
   tuple(
-    KeyError("Tracks to upload not found in SoundCloud: ['another project', 'some project']"),
+    SystemExit(2),
+    '''
+      ✗ Uploading "some project.wav" (not found in SoundCloud)    0:00:…       0/29   
+                                                                               bytes  
+      ✗ Uploading "another project.wav" (not found in SoundCloud) 0:00:…       0/32   
+                                                                               bytes  
+  
+    ''',
+    '',
     dict({
       'get': _CallList([
         _Call(

--- a/tests/render/conftest.py
+++ b/tests/render/conftest.py
@@ -146,6 +146,8 @@ def render_mocks(
 
         mock_get_int_config_var.side_effect = get_int_config_var
 
+        mock_upload.return_value = 0
+
         yield RenderMocks(
             duration_delta=mock_duration_delta,
             get_int_config_var=mock_get_int_config_var,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -46,14 +46,18 @@ def test_main_tracks_not_found(
     requests_mocks: RequestsMocks, snapshot: SnapshotAssertion, some_paths: list[Path]
 ) -> None:
     """Test main when tracks are not found/matched in the upstream database."""
-    with pytest.raises(KeyError) as exc_info:
-        CliRunner(mix_stderr=False).invoke(
-            upload,
-            [str(path.parent.resolve()) for path in some_paths],
-            catch_exceptions=False,
-        )
+    result = CliRunner(mix_stderr=False).invoke(
+        upload,
+        [str(path.parent.resolve()) for path in some_paths],
+        catch_exceptions=False,
+    )
 
-    assert (exc_info.value, requests_mocks.mock_calls) == snapshot
+    assert (
+        result.exception,
+        result.stdout,
+        result.stderr,
+        requests_mocks.mock_calls,
+    ) == snapshot
 
 
 def test_main_tracks_newer(
@@ -80,6 +84,7 @@ def test_main_tracks_newer(
             return mock.Mock(
                 st_mode=ST_MODE_IS_FILE,
                 st_mtime=datetime.datetime.fromisoformat(old_timestamp).timestamp(),
+                st_size=1_234_567,
             )
 
         return original_stat(self, *args, **kwargs)


### PR DESCRIPTION
After #9's render progress tweaks, upload progress gets analogous treatment.

# Changes

* Copy render `rich.progress.Progress` wrapper for upload
* Default task description color
* No longer fail all uploads if one is missing in the upstream database
* Return exit codes from upload
* Pass through `self.console` everywhere, to be thorough