### PR TITLE
Warn on Output Arcade missing kits, during analyze

### DIFF
--- a/src/music/commands/analyze/command.py
+++ b/src/music/commands/analyze/command.py
@@ -1,34 +1,16 @@
 """Analyze command."""
 
-import base64
-import os
-import sqlite3
-import xml.etree.ElementTree as ET
-from collections.abc import Iterator
-from contextlib import closing
-from dataclasses import dataclass
-from functools import cache
 from pathlib import Path
 
 import click
 import rich.console
 import rich.rule
 import rich.table
-import rpp  # type: ignore[import-untyped]
 
+from music.commands.analyze import process
 from music.utils import project
 
-_PLUGIN_TAGS = ("AU", "CLAP", "DX", "JS", "LV2", "VST")
 _MAX_SETTING_PREVIEW_CHARS = 240
-
-
-@dataclass(frozen=True)
-class PluginInstance:
-    """A plugin instance and the track it belongs to."""
-
-    track_number: int
-    track_name: str
-    plugin_name: str
 
 
 @click.command("analyze")
@@ -59,20 +41,21 @@ def main(project_paths: list[Path], plugins: bool) -> None:
     console = rich.console.Console()
 
     for i, project_file in enumerate(project_files):
+        analyzed_project = process.AnalyzeProject.from_project_file(project_file)
         if i > 0:
             console.print()
         console.print(rich.rule.Rule(f"[bold cyan]{project_file.stem}[/bold cyan]"))
-        for warning in iter_warnings(project_file):
+        for warning in analyzed_project.iter_warnings():
             console.print(f"  [yellow]Warning:[/yellow] {warning}")
         if plugins:
-            console.print(_plugins_table(project_file))
+            console.print(_plugins_table(analyzed_project))
         else:
-            for setting in iter_encoded_settings(project_file):
+            for setting in analyzed_project.iter_encoded_settings():
                 console.print(f"  {_display_setting(setting)}")
 
 
 def _project_file(project_path: Path) -> Path:
-    """Normalize either a project directory or an .rpp file into a file path."""
+    """Normalize either a project directory or an `.rpp` file into a file path."""
     return (
         project_path
         if project_path.is_file()
@@ -80,13 +63,7 @@ def _project_file(project_path: Path) -> Path:
     )
 
 
-def _iter_plugins(project_files: list[Path]) -> Iterator[str]:
-    """List plugin names used across the given project files."""
-    for project_file in project_files:
-        yield from iter_plugin_names(project_file)
-
-
-def _plugins_table(project_file: Path) -> rich.table.Table:
+def _plugins_table(analyzed_project: process.AnalyzeProject) -> rich.table.Table:
     """Render plugin instances for a project as a table."""
     table = rich.table.Table(show_header=True)
     table.add_column("Plugin")
@@ -94,7 +71,7 @@ def _plugins_table(project_file: Path) -> rich.table.Table:
     table.add_column("Track Name")
 
     plugins = sorted(
-        iter_plugin_instances(project_file),
+        analyzed_project.iter_plugin_instances(),
         key=lambda plugin: (
             plugin.plugin_name.casefold(),
             plugin.track_number,
@@ -111,102 +88,6 @@ def _plugins_table(project_file: Path) -> rich.table.Table:
     return table
 
 
-def iter_encoded_settings(project_fil: Path) -> Iterator[str]:
-    """Parse a Reaper project and return plugin settings encoded in base64."""
-    parsed_project = _parse_project(project_fil)
-
-    plugins = (
-        plugin for tag in _PLUGIN_TAGS for plugin in parsed_project.findall(f".//{tag}")
-    )
-    for plugin in plugins:
-        if arcade_state := _arcade_state_xml(plugin):
-            yield arcade_state.decode("utf-8")
-            continue
-
-        raw = "".join(
-            child.strip() for child in plugin.children if isinstance(child, str)
-        )
-        if decode := b64_ascii(raw):
-            yield decode
-
-
-def iter_plugin_names(project_fil: Path) -> Iterator[str]:
-    """Parse a Reaper project and return plugin names."""
-    yield from (plugin.plugin_name for plugin in iter_plugin_instances(project_fil))
-
-
-def iter_plugin_instances(project_fil: Path) -> Iterator[PluginInstance]:
-    """Parse a Reaper project and return plugins with their track locations."""
-    parsed_project = _parse_project(project_fil)
-
-    for track_number, track in enumerate(parsed_project.findall(".//TRACK"), start=1):
-        track_name = _track_name(track)
-        for tag in _PLUGIN_TAGS:
-            for plugin in track.findall(f".//{tag}"):
-                yield PluginInstance(
-                    track_number=track_number,
-                    track_name=track_name,
-                    plugin_name=_plugin_name(plugin),
-                )
-
-
-def _plugin_name(plugin: rpp.Element) -> str:
-    """Render a plugin's saved RPP attributes as a display name."""
-    name = str(plugin.attrib[0])
-    if plugin.tag == "JS":
-        return f"JS: {_jsfx_display_name(name)}"
-    return name
-
-
-def _track_name(track: rpp.Element) -> str:
-    """Return a track's saved name, if present."""
-    for child in track.children:
-        if isinstance(child, list) and child and child[0] == "NAME":
-            return str(child[1])
-    return ""
-
-
-def _jsfx_display_name(path: str) -> str:
-    """Resolve a JSFX script path to a human-readable display name."""
-    if jsfx_file := _jsfx_file(path):
-        if desc := _jsfx_desc(jsfx_file):
-            return desc
-
-    return Path(path).stem.replace("_", " ")
-
-
-@cache
-def _jsfx_file(path: str) -> Path | None:
-    """Find the installed JSFX file for a saved Reaper script path."""
-    for root in _jsfx_search_paths():
-        candidate = root / path
-        if candidate.is_file():
-            return candidate
-    return None
-
-
-def _jsfx_search_paths() -> tuple[Path, ...]:
-    """Return local directories where REAPER JSFX files may be installed."""
-    return (
-        Path.home() / "Library/Application Support/REAPER/Effects",
-        Path("/Applications/REAPER.app/Contents/InstallFiles/Effects"),
-    )
-
-
-def _jsfx_desc(jsfx_file: Path) -> str | None:
-    """Return the last declared JSFX desc label, if present."""
-    desc = None
-    for line in _jsfx_lines(jsfx_file):
-        if line.startswith("desc:"):
-            desc = line.removeprefix("desc:").strip()
-    return desc
-
-
-def _jsfx_lines(jsfx_file: Path) -> list[str]:
-    """Read a JSFX file, tolerating legacy REAPER effect encodings."""
-    return jsfx_file.read_text(encoding="utf-8", errors="replace").splitlines()
-
-
 def _display_setting(setting: str) -> str:
     """Render plugin settings as compact one-line previews."""
     single_line = " ".join(setting.split())
@@ -216,183 +97,3 @@ def _display_setting(setting: str) -> str:
     preview = single_line[:_MAX_SETTING_PREVIEW_CHARS].rstrip()
     truncated = len(single_line) - len(preview)
     return f"{preview}... [{truncated} more chars]"
-
-
-def iter_warnings(project_fil: Path) -> Iterator[str]:
-    """Parse a Reaper project and return plugin warnings."""
-    parsed_project = _parse_project(project_fil)
-
-    for track_number, track in enumerate(parsed_project.findall(".//TRACK"), start=1):
-        track_name = _track_name(track)
-        fxchain = next(
-            (
-                child
-                for child in track.children
-                if getattr(child, "tag", None) == "FXCHAIN"
-            ),
-            None,
-        )
-        if fxchain is None:
-            continue
-
-        for plugin in fxchain.children:
-            if getattr(plugin, "tag", None) != "AU":
-                continue
-            if "Arcade" not in str(plugin.attrib[0]):
-                continue
-            yield from _iter_arcade_warnings(track_number, track_name, plugin)
-
-
-def _parse_project(project_fil: Path) -> rpp.Element:
-    """Parse a Reaper project file."""
-    with open(project_fil) as fil:
-        return rpp.load(fil)
-
-
-def _iter_arcade_warnings(
-    track_number: int, track_name: str, plugin: rpp.Element
-) -> Iterator[str]:
-    """Inspect an Arcade AU state blob for detectable missing content issues."""
-    state = _arcade_state_xml(plugin)
-    if state is None:
-        return
-
-    root = ET.fromstring(state)
-    hyperion_preset = root.find("./Hyperion_Preset/info")
-    looper_preset = root.find("./Looper_Preset/info")
-
-    if looper_preset is not None:
-        yield from _iter_arcade_looper_warnings(track_number, track_name, looper_preset)
-    if hyperion_preset is not None:
-        yield from _iter_arcade_hyperion_warnings(
-            track_number, track_name, root, hyperion_preset
-        )
-
-
-def _iter_arcade_looper_warnings(
-    track_number: int, track_name: str, preset: ET.Element
-) -> Iterator[str]:
-    """Warn when a sampler/looper Arcade kit is not installed locally."""
-    preset_name = preset.attrib.get("name", "Unknown Arcade preset")
-    preset_uuid = preset.attrib.get("uuid", "")
-    if preset_uuid and preset_uuid not in _arcade_installed_kit_uuids():
-        yield (
-            f'Arcade sampler "{preset_name}" on track {track_number} "{track_name}" '
-            f"is not "
-            f"installed locally (kit UUID: {preset_uuid})"
-        )
-
-
-def _iter_arcade_hyperion_warnings(
-    track_number: int, track_name: str, root: ET.Element, preset: ET.Element
-) -> Iterator[str]:
-    """Warn when a Hyperion Arcade preset is missing installed source content."""
-    preset_name = preset.attrib.get("name", "Unknown Arcade preset")
-    installed_sources = _arcade_installed_source_uuids()
-    missing_sources = sorted(
-        {
-            source_uuid
-            for source_uuid in (
-                elem.attrib.get("LoadedSourceUuid", "")
-                for elem in root.findall(".//HyperionLoadedSource")
-            )
-            if source_uuid and source_uuid not in installed_sources
-        }
-    )
-    has_internal_error = (
-        root.find('.//HyperionFxBusSettings[@Name="error"]') is not None
-    )
-
-    if missing_sources or has_internal_error:
-        detail = (
-            f'Arcade instrument "{preset_name}" on track {track_number} "{track_name}"'
-        )
-        if missing_sources:
-            sources = ", ".join(missing_sources)
-            yield f"{detail} references missing source content: {sources}"
-        if has_internal_error and missing_sources:
-            yield f'{detail} has an internal "error" state in its saved plugin data'
-
-
-def _arcade_state_xml(plugin: rpp.Element) -> bytes | None:
-    """Extract Arcade's nested JUCE state XML from an AU plugin chunk."""
-    if "Arcade" not in str(plugin.attrib[0]):
-        return None
-
-    raw = "".join(child.strip() for child in plugin.children if isinstance(child, str))
-    if not raw:
-        return None
-
-    try:
-        outer = base64.b64decode(raw)
-        plist_start = outer.index(b"<?xml")
-        plist_end = outer.index(b"</plist>") + len(b"</plist>")
-        outer_plist = outer[plist_start:plist_end]
-        juce_state = rpp_plist_value(outer_plist, "jucePluginState")
-        if not isinstance(juce_state, bytes):
-            return None
-
-        state_start = juce_state.index(b"<?xml")
-        state_end = juce_state.index(b"</state_info>") + len(b"</state_info>")
-    except (ValueError, KeyError):
-        return None
-    return juce_state[state_start:state_end]
-
-
-def _arcade_content_root() -> Path:
-    """Return Arcade's content install root, overridable for tests."""
-    return Path(
-        os.environ.get(
-            "ARCADE_CONTENT_ROOT",
-            "/Library/Application Support/Output/Arcade/Arcade Content",
-        )
-    )
-
-
-def _arcade_db_path() -> Path:
-    """Return Arcade's local metadata database, overridable for tests."""
-    return Path(
-        os.environ.get(
-            "ARCADE_DB_PATH",
-            "/Library/Application Support/Output/Arcade/local.db",
-        )
-    )
-
-
-def _arcade_installed_kit_uuids() -> set[str]:
-    """Return the set of Arcade kit UUIDs installed in the local metadata DB."""
-    db_path = _arcade_db_path()
-    if not db_path.exists():
-        return set()
-
-    with closing(sqlite3.connect(db_path)) as con:
-        return {uuid for (uuid,) in con.execute("select uuid from kits")}
-
-
-def _arcade_installed_source_uuids() -> set[str]:
-    """Return the set of Arcade instrument source UUIDs in the local metadata DB."""
-    db_path = _arcade_db_path()
-    if not db_path.exists():
-        return set()
-
-    with closing(sqlite3.connect(db_path)) as con:
-        return {uuid for (uuid,) in con.execute("select uuid from sound_sources")}
-
-
-def rpp_plist_value(plist_xml: bytes, key: str) -> object:
-    """Look up a plist value by key from a parsed Arcade AU state blob."""
-    import plistlib
-
-    return plistlib.loads(plist_xml)[key]
-
-
-def b64_ascii(s: str) -> str | None:
-    """Try to decode a base64 string.
-
-    Many VST settings are encoded in Reaper as base64. Return None if it is not
-    one of those strings.
-    """
-    try:
-        return base64.b64decode(s).decode("ascii")
-    except UnicodeDecodeError:
-        return None

--- a/src/music/commands/analyze/command.py
+++ b/src/music/commands/analyze/command.py
@@ -19,6 +19,7 @@ import rpp  # type: ignore[import-untyped]
 from music.utils import project
 
 _PLUGIN_TAGS = ("AU", "CLAP", "DX", "JS", "LV2", "VST")
+_MAX_SETTING_PREVIEW_CHARS = 240
 
 
 @dataclass(frozen=True)
@@ -67,7 +68,7 @@ def main(project_paths: list[Path], plugins: bool) -> None:
             console.print(_plugins_table(project_file))
         else:
             for setting in iter_encoded_settings(project_file):
-                console.print(f"  {setting}")
+                console.print(f"  {_display_setting(setting)}")
 
 
 def _project_file(project_path: Path) -> Path:
@@ -118,10 +119,15 @@ def iter_encoded_settings(project_fil: Path) -> Iterator[str]:
         plugin for tag in _PLUGIN_TAGS for plugin in parsed_project.findall(f".//{tag}")
     )
     for plugin in plugins:
-        successful_decodes = (
-            decode for child in plugin.children if (decode := b64_ascii(child))
+        if arcade_state := _arcade_state_xml(plugin):
+            yield arcade_state.decode("utf-8")
+            continue
+
+        raw = "".join(
+            child.strip() for child in plugin.children if isinstance(child, str)
         )
-        yield from successful_decodes
+        if decode := b64_ascii(raw):
+            yield decode
 
 
 def iter_plugin_names(project_fil: Path) -> Iterator[str]:
@@ -199,6 +205,17 @@ def _jsfx_desc(jsfx_file: Path) -> str | None:
 def _jsfx_lines(jsfx_file: Path) -> list[str]:
     """Read a JSFX file, tolerating legacy REAPER effect encodings."""
     return jsfx_file.read_text(encoding="utf-8", errors="replace").splitlines()
+
+
+def _display_setting(setting: str) -> str:
+    """Render plugin settings as compact one-line previews."""
+    single_line = " ".join(setting.split())
+    if len(single_line) <= _MAX_SETTING_PREVIEW_CHARS:
+        return single_line
+
+    preview = single_line[:_MAX_SETTING_PREVIEW_CHARS].rstrip()
+    truncated = len(single_line) - len(preview)
+    return f"{preview}... [{truncated} more chars]"
 
 
 def iter_warnings(project_fil: Path) -> Iterator[str]:
@@ -290,6 +307,9 @@ def _iter_arcade_hyperion_warnings(
 
 def _arcade_state_xml(plugin: rpp.Element) -> bytes | None:
     """Extract Arcade's nested JUCE state XML from an AU plugin chunk."""
+    if "Arcade" not in str(plugin.attrib[0]):
+        return None
+
     raw = "".join(child.strip() for child in plugin.children if isinstance(child, str))
     if not raw:
         return None

--- a/src/music/commands/analyze/command.py
+++ b/src/music/commands/analyze/command.py
@@ -5,6 +5,7 @@ import os
 import sqlite3
 import xml.etree.ElementTree as ET
 from collections.abc import Iterator
+from contextlib import closing
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
@@ -231,14 +232,6 @@ def _parse_project(project_fil: Path) -> rpp.Element:
         return rpp.load(fil)
 
 
-def _track_name(track: rpp.Element) -> str:
-    """Extract a Reaper track's display name."""
-    for child in track.children:
-        if isinstance(child, list) and child and child[0] == "NAME":
-            return str(child[1])
-    return "<unnamed track>"
-
-
 def _iter_arcade_warnings(track_name: str, plugin: rpp.Element) -> Iterator[str]:
     """Inspect an Arcade AU state blob for detectable missing content issues."""
     state = _arcade_state_xml(plugin)
@@ -343,7 +336,7 @@ def _arcade_installed_kit_uuids() -> set[str]:
     if not db_path.exists():
         return set()
 
-    with sqlite3.connect(db_path) as con:
+    with closing(sqlite3.connect(db_path)) as con:
         return {uuid for (uuid,) in con.execute("select uuid from kits")}
 
 
@@ -353,7 +346,7 @@ def _arcade_installed_source_uuids() -> set[str]:
     if not db_path.exists():
         return set()
 
-    with sqlite3.connect(db_path) as con:
+    with closing(sqlite3.connect(db_path)) as con:
         return {uuid for (uuid,) in con.execute("select uuid from sound_sources")}
 
 

--- a/src/music/commands/analyze/command.py
+++ b/src/music/commands/analyze/command.py
@@ -1,6 +1,8 @@
 """Analyze command."""
 
 import base64
+import os
+import xml.etree.ElementTree as ET
 from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import cache
@@ -57,6 +59,8 @@ def main(project_paths: list[Path], plugins: bool) -> None:
         if i > 0:
             console.print()
         console.print(rich.rule.Rule(f"[bold cyan]{project_file.stem}[/bold cyan]"))
+        for warning in iter_warnings(project_file):
+            console.print(f"  [yellow]Warning:[/yellow] {warning}")
         if plugins:
             console.print(_plugins_table(project_file))
         else:
@@ -195,10 +199,118 @@ def _jsfx_lines(jsfx_file: Path) -> list[str]:
     return jsfx_file.read_text(encoding="utf-8", errors="replace").splitlines()
 
 
+def iter_warnings(project_fil: Path) -> Iterator[str]:
+    """Parse a Reaper project and return plugin warnings."""
+    parsed_project = _parse_project(project_fil)
+
+    for track in parsed_project.findall(".//TRACK"):
+        track_name = _track_name(track)
+        fxchain = next(
+            (
+                child
+                for child in track.children
+                if getattr(child, "tag", None) == "FXCHAIN"
+            ),
+            None,
+        )
+        if fxchain is None:
+            continue
+
+        for plugin in fxchain.children:
+            if getattr(plugin, "tag", None) != "AU":
+                continue
+            if "Arcade" not in str(plugin.attrib[0]):
+                continue
+            yield from _iter_arcade_warnings(track_name, plugin)
+
+
 def _parse_project(project_fil: Path) -> rpp.Element:
     """Parse a Reaper project file."""
     with open(project_fil) as fil:
         return rpp.load(fil)
+
+
+def _track_name(track: rpp.Element) -> str:
+    """Extract a Reaper track's display name."""
+    for child in track.children:
+        if isinstance(child, list) and child and child[0] == "NAME":
+            return str(child[1])
+    return "<unnamed track>"
+
+
+def _iter_arcade_warnings(track_name: str, plugin: rpp.Element) -> Iterator[str]:
+    """Inspect an Arcade AU state blob for detectable missing content issues."""
+    state = _arcade_state_xml(plugin)
+    if state is None:
+        return
+
+    root = ET.fromstring(state)
+    preset = root.find("./Hyperion_Preset/info")
+    if preset is None:
+        return
+
+    preset_name = preset.attrib.get("name", "Unknown Arcade preset")
+    missing_sources = sorted(
+        {
+            source_uuid
+            for source_uuid in (
+                elem.attrib.get("LoadedSourceUuid", "")
+                for elem in root.findall(".//HyperionLoadedSource")
+            )
+            if source_uuid
+            and not (_arcade_content_root() / "Sources" / source_uuid).exists()
+        }
+    )
+    has_internal_error = (
+        root.find('.//HyperionFxBusSettings[@Name="error"]') is not None
+    )
+
+    if missing_sources or has_internal_error:
+        detail = f'Arcade instrument "{preset_name}" on track "{track_name}"'
+        if missing_sources:
+            sources = ", ".join(missing_sources)
+            yield f"{detail} references missing source content: {sources}"
+        if has_internal_error:
+            yield f'{detail} has an internal "error" state in its saved plugin data'
+
+
+def _arcade_state_xml(plugin: rpp.Element) -> bytes | None:
+    """Extract Arcade's nested JUCE state XML from an AU plugin chunk."""
+    raw = "".join(child.strip() for child in plugin.children if isinstance(child, str))
+    if not raw:
+        return None
+
+    try:
+        outer = base64.b64decode(raw)
+        plist_start = outer.index(b"<?xml")
+        plist_end = outer.index(b"</plist>") + len(b"</plist>")
+        outer_plist = outer[plist_start:plist_end]
+        juce_state = rpp_plist_value(outer_plist, "jucePluginState")
+        if not isinstance(juce_state, bytes):
+            return None
+
+        state_start = juce_state.index(b"<?xml")
+        state_end = juce_state.index(b"</state_info>") + len(b"</state_info>")
+    except (ValueError, KeyError):
+        return None
+    return juce_state[state_start:state_end]
+
+
+def _arcade_content_root() -> Path:
+    """Return Arcade's content install root, overridable for tests."""
+    return Path(
+        os.environ.get(
+            "ARCADE_CONTENT_ROOT",
+            "/Library/Application Support/Output/Arcade/Arcade Content",
+        )
+    )
+
+
+def rpp_plist_value(plist_xml: bytes, key: str) -> object:
+    """Look up a plist value by key from a parsed Arcade AU state blob."""
+    import plistlib
+
+    return plistlib.loads(plist_xml)[key]
 
 
 def b64_ascii(s: str) -> str | None:

--- a/src/music/commands/analyze/command.py
+++ b/src/music/commands/analyze/command.py
@@ -2,6 +2,7 @@
 
 import base64
 import os
+import sqlite3
 import xml.etree.ElementTree as ET
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -245,10 +246,30 @@ def _iter_arcade_warnings(track_name: str, plugin: rpp.Element) -> Iterator[str]
         return
 
     root = ET.fromstring(state)
-    preset = root.find("./Hyperion_Preset/info")
-    if preset is None:
-        return
+    hyperion_preset = root.find("./Hyperion_Preset/info")
+    looper_preset = root.find("./Looper_Preset/info")
 
+    if looper_preset is not None:
+        yield from _iter_arcade_looper_warnings(track_name, looper_preset)
+    if hyperion_preset is not None:
+        yield from _iter_arcade_hyperion_warnings(track_name, root, hyperion_preset)
+
+
+def _iter_arcade_looper_warnings(track_name: str, preset: ET.Element) -> Iterator[str]:
+    """Warn when a sampler/looper Arcade kit is not installed locally."""
+    preset_name = preset.attrib.get("name", "Unknown Arcade preset")
+    preset_uuid = preset.attrib.get("uuid", "")
+    if preset_uuid and preset_uuid not in _arcade_installed_kit_uuids():
+        yield (
+            f'Arcade sampler "{preset_name}" on track "{track_name}" is not '
+            f"installed locally (kit UUID: {preset_uuid})"
+        )
+
+
+def _iter_arcade_hyperion_warnings(
+    track_name: str, root: ET.Element, preset: ET.Element
+) -> Iterator[str]:
+    """Warn when a Hyperion Arcade preset is missing installed source content."""
     preset_name = preset.attrib.get("name", "Unknown Arcade preset")
     missing_sources = sorted(
         {
@@ -304,6 +325,26 @@ def _arcade_content_root() -> Path:
             "/Library/Application Support/Output/Arcade/Arcade Content",
         )
     )
+
+
+def _arcade_db_path() -> Path:
+    """Return Arcade's local metadata database, overridable for tests."""
+    return Path(
+        os.environ.get(
+            "ARCADE_DB_PATH",
+            "/Library/Application Support/Output/Arcade/local.db",
+        )
+    )
+
+
+def _arcade_installed_kit_uuids() -> set[str]:
+    """Return the set of Arcade kit UUIDs installed in the local metadata DB."""
+    db_path = _arcade_db_path()
+    if not db_path.exists():
+        return set()
+
+    with sqlite3.connect(db_path) as con:
+        return {uuid for (uuid,) in con.execute("select uuid from kits")}
 
 
 def rpp_plist_value(plist_xml: bytes, key: str) -> object:

--- a/src/music/commands/analyze/command.py
+++ b/src/music/commands/analyze/command.py
@@ -222,7 +222,7 @@ def iter_warnings(project_fil: Path) -> Iterator[str]:
     """Parse a Reaper project and return plugin warnings."""
     parsed_project = _parse_project(project_fil)
 
-    for track in parsed_project.findall(".//TRACK"):
+    for track_number, track in enumerate(parsed_project.findall(".//TRACK"), start=1):
         track_name = _track_name(track)
         fxchain = next(
             (
@@ -240,7 +240,7 @@ def iter_warnings(project_fil: Path) -> Iterator[str]:
                 continue
             if "Arcade" not in str(plugin.attrib[0]):
                 continue
-            yield from _iter_arcade_warnings(track_name, plugin)
+            yield from _iter_arcade_warnings(track_number, track_name, plugin)
 
 
 def _parse_project(project_fil: Path) -> rpp.Element:
@@ -249,7 +249,9 @@ def _parse_project(project_fil: Path) -> rpp.Element:
         return rpp.load(fil)
 
 
-def _iter_arcade_warnings(track_name: str, plugin: rpp.Element) -> Iterator[str]:
+def _iter_arcade_warnings(
+    track_number: int, track_name: str, plugin: rpp.Element
+) -> Iterator[str]:
     """Inspect an Arcade AU state blob for detectable missing content issues."""
     state = _arcade_state_xml(plugin)
     if state is None:
@@ -260,24 +262,29 @@ def _iter_arcade_warnings(track_name: str, plugin: rpp.Element) -> Iterator[str]
     looper_preset = root.find("./Looper_Preset/info")
 
     if looper_preset is not None:
-        yield from _iter_arcade_looper_warnings(track_name, looper_preset)
+        yield from _iter_arcade_looper_warnings(track_number, track_name, looper_preset)
     if hyperion_preset is not None:
-        yield from _iter_arcade_hyperion_warnings(track_name, root, hyperion_preset)
+        yield from _iter_arcade_hyperion_warnings(
+            track_number, track_name, root, hyperion_preset
+        )
 
 
-def _iter_arcade_looper_warnings(track_name: str, preset: ET.Element) -> Iterator[str]:
+def _iter_arcade_looper_warnings(
+    track_number: int, track_name: str, preset: ET.Element
+) -> Iterator[str]:
     """Warn when a sampler/looper Arcade kit is not installed locally."""
     preset_name = preset.attrib.get("name", "Unknown Arcade preset")
     preset_uuid = preset.attrib.get("uuid", "")
     if preset_uuid and preset_uuid not in _arcade_installed_kit_uuids():
         yield (
-            f'Arcade sampler "{preset_name}" on track "{track_name}" is not '
+            f'Arcade sampler "{preset_name}" on track {track_number} "{track_name}" '
+            f"is not "
             f"installed locally (kit UUID: {preset_uuid})"
         )
 
 
 def _iter_arcade_hyperion_warnings(
-    track_name: str, root: ET.Element, preset: ET.Element
+    track_number: int, track_name: str, root: ET.Element, preset: ET.Element
 ) -> Iterator[str]:
     """Warn when a Hyperion Arcade preset is missing installed source content."""
     preset_name = preset.attrib.get("name", "Unknown Arcade preset")
@@ -297,7 +304,9 @@ def _iter_arcade_hyperion_warnings(
     )
 
     if missing_sources or has_internal_error:
-        detail = f'Arcade instrument "{preset_name}" on track "{track_name}"'
+        detail = (
+            f'Arcade instrument "{preset_name}" on track {track_number} "{track_name}"'
+        )
         if missing_sources:
             sources = ", ".join(missing_sources)
             yield f"{detail} references missing source content: {sources}"

--- a/src/music/commands/analyze/command.py
+++ b/src/music/commands/analyze/command.py
@@ -271,6 +271,7 @@ def _iter_arcade_hyperion_warnings(
 ) -> Iterator[str]:
     """Warn when a Hyperion Arcade preset is missing installed source content."""
     preset_name = preset.attrib.get("name", "Unknown Arcade preset")
+    installed_sources = _arcade_installed_source_uuids()
     missing_sources = sorted(
         {
             source_uuid
@@ -278,8 +279,7 @@ def _iter_arcade_hyperion_warnings(
                 elem.attrib.get("LoadedSourceUuid", "")
                 for elem in root.findall(".//HyperionLoadedSource")
             )
-            if source_uuid
-            and not (_arcade_content_root() / "Sources" / source_uuid).exists()
+            if source_uuid and source_uuid not in installed_sources
         }
     )
     has_internal_error = (
@@ -291,7 +291,7 @@ def _iter_arcade_hyperion_warnings(
         if missing_sources:
             sources = ", ".join(missing_sources)
             yield f"{detail} references missing source content: {sources}"
-        if has_internal_error:
+        if has_internal_error and missing_sources:
             yield f'{detail} has an internal "error" state in its saved plugin data'
 
 
@@ -345,6 +345,16 @@ def _arcade_installed_kit_uuids() -> set[str]:
 
     with sqlite3.connect(db_path) as con:
         return {uuid for (uuid,) in con.execute("select uuid from kits")}
+
+
+def _arcade_installed_source_uuids() -> set[str]:
+    """Return the set of Arcade instrument source UUIDs in the local metadata DB."""
+    db_path = _arcade_db_path()
+    if not db_path.exists():
+        return set()
+
+    with sqlite3.connect(db_path) as con:
+        return {uuid for (uuid,) in con.execute("select uuid from sound_sources")}
 
 
 def rpp_plist_value(plist_xml: bytes, key: str) -> object:

--- a/src/music/commands/analyze/output/__init__.py
+++ b/src/music/commands/analyze/output/__init__.py
@@ -1,0 +1,1 @@
+"""Vendor-specific analyze helpers."""

--- a/src/music/commands/analyze/output/arcade.py
+++ b/src/music/commands/analyze/output/arcade.py
@@ -1,0 +1,153 @@
+"""Output Arcade-specific analyze helpers."""
+
+import base64
+import os
+import sqlite3
+import xml.etree.ElementTree as ET
+from collections.abc import Iterator
+from contextlib import closing
+from pathlib import Path
+
+import rpp  # type: ignore[import-untyped]
+
+
+def is_arcade_plugin(plugin: rpp.Element) -> bool:
+    """Return whether the plugin chunk belongs to Output Arcade."""
+    return getattr(plugin, "tag", None) == "AU" and "Arcade" in str(plugin.attrib[0])
+
+
+def iter_warnings(
+    track_number: int, track_name: str, plugin: rpp.Element
+) -> Iterator[str]:
+    """Inspect an Arcade AU state blob for detectable missing content issues."""
+    state = arcade_state_xml(plugin)
+    if state is None:
+        return
+
+    root = ET.fromstring(state)
+    hyperion_preset = root.find("./Hyperion_Preset/info")
+    looper_preset = root.find("./Looper_Preset/info")
+
+    if looper_preset is not None:
+        yield from _iter_arcade_looper_warnings(track_number, track_name, looper_preset)
+    if hyperion_preset is not None:
+        yield from _iter_arcade_hyperion_warnings(
+            track_number, track_name, root, hyperion_preset
+        )
+
+
+def arcade_state_xml(plugin: rpp.Element) -> bytes | None:
+    """Extract Arcade's nested JUCE state XML from an AU plugin chunk."""
+    if not is_arcade_plugin(plugin):
+        return None
+
+    raw = "".join(child.strip() for child in plugin.children if isinstance(child, str))
+    if not raw:
+        return None
+
+    try:
+        outer = base64.b64decode(raw)
+        plist_start = outer.index(b"<?xml")
+        plist_end = outer.index(b"</plist>") + len(b"</plist>")
+        outer_plist = outer[plist_start:plist_end]
+        juce_state = rpp_plist_value(outer_plist, "jucePluginState")
+        if not isinstance(juce_state, bytes):
+            return None
+
+        state_start = juce_state.index(b"<?xml")
+        state_end = juce_state.index(b"</state_info>") + len(b"</state_info>")
+    except (ValueError, KeyError):
+        return None
+    return juce_state[state_start:state_end]
+
+
+def _iter_arcade_looper_warnings(
+    track_number: int, track_name: str, preset: ET.Element
+) -> Iterator[str]:
+    """Warn when a sampler/looper Arcade kit is not installed locally."""
+    preset_name = preset.attrib.get("name", "Unknown Arcade preset")
+    preset_uuid = preset.attrib.get("uuid", "")
+    if preset_uuid and preset_uuid not in _arcade_installed_kit_uuids():
+        yield (
+            f'Arcade sampler "{preset_name}" on track {track_number} "{track_name}" '
+            f"is not "
+            f"installed locally (kit UUID: {preset_uuid})"
+        )
+
+
+def _iter_arcade_hyperion_warnings(
+    track_number: int, track_name: str, root: ET.Element, preset: ET.Element
+) -> Iterator[str]:
+    """Warn when a Hyperion Arcade preset is missing installed source content."""
+    preset_name = preset.attrib.get("name", "Unknown Arcade preset")
+    installed_sources = _arcade_installed_source_uuids()
+    missing_sources = sorted(
+        {
+            source_uuid
+            for source_uuid in (
+                elem.attrib.get("LoadedSourceUuid", "")
+                for elem in root.findall(".//HyperionLoadedSource")
+            )
+            if source_uuid and source_uuid not in installed_sources
+        }
+    )
+    has_internal_error = (
+        root.find('.//HyperionFxBusSettings[@Name="error"]') is not None
+    )
+
+    if missing_sources or has_internal_error:
+        detail = (
+            f'Arcade instrument "{preset_name}" on track {track_number} "{track_name}"'
+        )
+        if missing_sources:
+            sources = ", ".join(missing_sources)
+            yield f"{detail} references missing source content: {sources}"
+        if has_internal_error and missing_sources:
+            yield f'{detail} has an internal "error" state in its saved plugin data'
+
+
+def _arcade_content_root() -> Path:
+    """Return Arcade's content install root, overridable for tests."""
+    return Path(
+        os.environ.get(
+            "ARCADE_CONTENT_ROOT",
+            "/Library/Application Support/Output/Arcade/Arcade Content",
+        )
+    )
+
+
+def _arcade_db_path() -> Path:
+    """Return Arcade's local metadata database, overridable for tests."""
+    return Path(
+        os.environ.get(
+            "ARCADE_DB_PATH",
+            "/Library/Application Support/Output/Arcade/local.db",
+        )
+    )
+
+
+def _arcade_installed_kit_uuids() -> set[str]:
+    """Return the set of Arcade kit UUIDs installed in the local metadata DB."""
+    db_path = _arcade_db_path()
+    if not db_path.exists():
+        return set()
+
+    with closing(sqlite3.connect(db_path)) as con:
+        return {uuid for (uuid,) in con.execute("select uuid from kits")}
+
+
+def _arcade_installed_source_uuids() -> set[str]:
+    """Return the set of Arcade instrument source UUIDs in the local metadata DB."""
+    db_path = _arcade_db_path()
+    if not db_path.exists():
+        return set()
+
+    with closing(sqlite3.connect(db_path)) as con:
+        return {uuid for (uuid,) in con.execute("select uuid from sound_sources")}
+
+
+def rpp_plist_value(plist_xml: bytes, key: str) -> object:
+    """Look up a plist value by key from a parsed Arcade AU state blob."""
+    import plistlib
+
+    return plistlib.loads(plist_xml)[key]

--- a/src/music/commands/analyze/output/arcade.py
+++ b/src/music/commands/analyze/output/arcade.py
@@ -19,7 +19,13 @@ def is_arcade_plugin(plugin: rpp.Element) -> bool:
 def iter_warnings(
     track_number: int, track_name: str, plugin: rpp.Element
 ) -> Iterator[str]:
-    """Inspect an Arcade AU state blob for detectable missing content issues."""
+    """Inspect an Arcade AU state blob for missing-content issues.
+
+    Arcade saves different preset families under distinct XML sections. This
+    analyzer currently recognizes looper presets, which reference kit installs
+    via ``Looper_Preset``, and Hyperion presets, which reference instrument
+    source installs via ``Hyperion_Preset``.
+    """
     state = arcade_state_xml(plugin)
     if state is None:
         return
@@ -64,7 +70,7 @@ def arcade_state_xml(plugin: rpp.Element) -> bytes | None:
 def _iter_arcade_looper_warnings(
     track_number: int, track_name: str, preset: ET.Element
 ) -> Iterator[str]:
-    """Warn when a sampler/looper Arcade kit is not installed locally."""
+    """Warn when a looper-style Arcade preset references a missing kit install."""
     preset_name = preset.attrib.get("name", "Unknown Arcade preset")
     preset_uuid = preset.attrib.get("uuid", "")
     if preset_uuid and preset_uuid not in _arcade_installed_kit_uuids():
@@ -78,7 +84,7 @@ def _iter_arcade_looper_warnings(
 def _iter_arcade_hyperion_warnings(
     track_number: int, track_name: str, root: ET.Element, preset: ET.Element
 ) -> Iterator[str]:
-    """Warn when a Hyperion Arcade preset is missing installed source content."""
+    """Warn when a Hyperion Arcade preset references missing source content."""
     preset_name = preset.attrib.get("name", "Unknown Arcade preset")
     installed_sources = _arcade_installed_source_uuids()
     missing_sources = sorted(

--- a/src/music/commands/analyze/process.py
+++ b/src/music/commands/analyze/process.py
@@ -1,0 +1,159 @@
+"""Analyze processing for Reaper project files."""
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+
+import rpp  # type: ignore[import-untyped]
+
+from .output import arcade
+
+_PLUGIN_TAGS = ("AU", "CLAP", "DX", "JS", "LV2", "VST")
+
+
+@dataclass(frozen=True)
+class PluginInstance:
+    """A plugin instance and the track it belongs to."""
+
+    track_number: int
+    track_name: str
+    plugin_name: str
+
+
+@dataclass(frozen=True)
+class AnalyzeProject:
+    """A parsed Reaper project file with analyze-oriented query methods."""
+
+    project_file: Path
+    parsed_project: rpp.Element
+
+    @classmethod
+    def from_project_file(cls, project_file: Path) -> "AnalyzeProject":
+        """Parse a Reaper `.rpp` project file once for repeated analysis."""
+        with open(project_file) as fil:
+            parsed_project = rpp.load(fil)
+        return cls(project_file=project_file, parsed_project=parsed_project)
+
+    def iter_encoded_settings(self) -> Iterator[str]:
+        """Return plugin settings encoded in base64 from the parsed project."""
+        plugins = (
+            plugin
+            for tag in _PLUGIN_TAGS
+            for plugin in self.parsed_project.findall(f".//{tag}")
+        )
+        for plugin in plugins:
+            if arcade_state := arcade.arcade_state_xml(plugin):
+                yield arcade_state.decode("utf-8")
+                continue
+
+            raw = "".join(
+                child.strip() for child in plugin.children if isinstance(child, str)
+            )
+            if decode := b64_ascii(raw):
+                yield decode
+
+    def iter_plugin_names(self) -> Iterator[str]:
+        """Return plugin names from the parsed project."""
+        yield from (plugin.plugin_name for plugin in self.iter_plugin_instances())
+
+    def iter_plugin_instances(self) -> Iterator[PluginInstance]:
+        """Return plugins with their track locations from the parsed project."""
+        for track_number, track in enumerate(
+            self.parsed_project.findall(".//TRACK"), start=1
+        ):
+            track_name = _track_name(track)
+            for tag in _PLUGIN_TAGS:
+                for plugin in track.findall(f".//{tag}"):
+                    yield PluginInstance(
+                        track_number=track_number,
+                        track_name=track_name,
+                        plugin_name=_plugin_name(plugin),
+                    )
+
+    def iter_warnings(self) -> Iterator[str]:
+        """Return plugin warnings from the parsed project."""
+        for track_number, track in enumerate(
+            self.parsed_project.findall(".//TRACK"), start=1
+        ):
+            track_name = _track_name(track)
+            fxchain = next(
+                (
+                    child
+                    for child in track.children
+                    if getattr(child, "tag", None) == "FXCHAIN"
+                ),
+                None,
+            )
+            if fxchain is None:
+                continue
+
+            for plugin in fxchain.children:
+                if arcade.is_arcade_plugin(plugin):
+                    yield from arcade.iter_warnings(track_number, track_name, plugin)
+
+
+def _plugin_name(plugin: rpp.Element) -> str:
+    """Render a plugin's saved Reaper plugin chunk attributes as a display name."""
+    name = str(plugin.attrib[0])
+    if plugin.tag == "JS":
+        return f"JS: {_jsfx_display_name(name)}"
+    return name
+
+
+def _track_name(track: rpp.Element) -> str:
+    """Return a track's saved Reaper name, if present."""
+    for child in track.children:
+        if isinstance(child, list) and child and child[0] == "NAME":
+            return str(child[1])
+    return ""
+
+
+def _jsfx_display_name(path: str) -> str:
+    """Resolve a Reaper JSFX script path to a human-readable display name."""
+    if jsfx_file := _jsfx_file(path):
+        if desc := _jsfx_desc(jsfx_file):
+            return desc
+
+    return Path(path).stem.replace("_", " ")
+
+
+@cache
+def _jsfx_file(path: str) -> Path | None:
+    """Find the installed JSFX file for a saved Reaper script path."""
+    for root in _jsfx_search_paths():
+        candidate = root / path
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _jsfx_search_paths() -> tuple[Path, ...]:
+    """Return local directories where REAPER JSFX files may be installed."""
+    return (
+        Path.home() / "Library/Application Support/REAPER/Effects",
+        Path("/Applications/REAPER.app/Contents/InstallFiles/Effects"),
+    )
+
+
+def _jsfx_desc(jsfx_file: Path) -> str | None:
+    """Return the last declared JSFX desc label, if present."""
+    desc = None
+    for line in _jsfx_lines(jsfx_file):
+        if line.startswith("desc:"):
+            desc = line.removeprefix("desc:").strip()
+    return desc
+
+
+def _jsfx_lines(jsfx_file: Path) -> list[str]:
+    """Read a JSFX file, tolerating legacy REAPER effect encodings."""
+    return jsfx_file.read_text(encoding="utf-8", errors="replace").splitlines()
+
+
+def b64_ascii(s: str) -> str | None:
+    """Try to decode a base64 string from a Reaper plugin chunk."""
+    try:
+        return base64.b64decode(s).decode("ascii")
+    except UnicodeDecodeError:
+        return None

--- a/tests/commands/__snapshots__/test_analyze.ambr
+++ b/tests/commands/__snapshots__/test_analyze.ambr
@@ -1,4 +1,31 @@
 # serializer version: 1
+# name: test_main_does_not_warn_for_arcade_hyperion_installed_source
+  tuple(
+    '',
+    None,
+    '''
+      ─────────────────────────────────── Example ────────────────────────────────────
+        <?xml version="1.0" encoding="UTF-8"?><state_info><Hyperion_Preset><info 
+      name="Amped Up" uuid="kit-uuid" product_uuid="product-uuid" 
+      version="2.0.0"/><model><HyperionLoadedSource 
+      LoadedSourceUuid="loaded-source"/><HyperionFxBusSettings Name... [49 more chars]
+  
+    ''',
+  )
+# ---
+# name: test_main_does_not_warn_for_arcade_looper_installed_kit
+  tuple(
+    '',
+    None,
+    '''
+      ─────────────────────────────────── Example ────────────────────────────────────
+        <?xml version="1.0" encoding="UTF-8"?><state_info><Looper_Preset><info 
+      name="Downstream" uuid="downstream-kit" product_uuid="honey-product" 
+      version="1.3.0"/></Looper_Preset></state_info>
+  
+    ''',
+  )
+# ---
 # name: test_main_plugins_falls_back_to_clean_jsfx_basename
   tuple(
     '',
@@ -80,6 +107,75 @@
       ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━┩
       │ JS: Master Limiter │       1 │ Master     │
       └────────────────────┴─────────┴────────────┘
+  
+    ''',
+  )
+# ---
+# name: test_main_raw_mode_reassembles_chunked_arcade_state
+  tuple(
+    '',
+    None,
+    '''
+      ─────────────────────────────────── Example ────────────────────────────────────
+        Warning: Arcade sampler "Downstream very-long-state very-long-state 
+      very-long-state very-long-state very-long-state very-long-state very-long-state 
+      very-long-state very-long-state very-long-state very-long-state very-long-state 
+      very-long-state very-long-state very-long-state very-long-state very-long-state 
+      very-long-state very-long-state very-long-state " on track 1 "" is not installed
+      locally (kit UUID: downstream-kit)
+        <?xml version="1.0" encoding="UTF-8"?><state_info><Looper_Preset><info 
+      name="Downstream very-long-state very-long-state very-long-state very-long-state
+      very-long-state very-long-state very-long-state very-long-state very-long-state 
+      very-lon... [267 more chars]
+  
+    ''',
+  )
+# ---
+# name: test_main_raw_mode_sections
+  tuple(
+    '',
+    None,
+    '''
+      ─────────────────────────────────── Example ────────────────────────────────────
+        more
+        clap
+        dx
+        jsf
+        lv2
+        valid
+  
+    ''',
+  )
+# ---
+# name: test_main_warns_for_arcade_hyperion_missing_source
+  tuple(
+    '',
+    None,
+    '''
+      ─────────────────────────────────── Example ────────────────────────────────────
+        Warning: Arcade instrument "Amped Up" on track 1 "Bass note kit" references 
+      missing source content: missing-source
+        Warning: Arcade instrument "Amped Up" on track 1 "Bass note kit" has an 
+      internal "error" state in its saved plugin data
+        <?xml version="1.0" encoding="UTF-8"?><state_info><Hyperion_Preset><info 
+      name="Amped Up" uuid="kit-uuid" product_uuid="product-uuid" 
+      version="2.0.0"/><model><HyperionLoadedSource 
+      LoadedSourceUuid="missing-source"/><HyperionFxBusSettings Nam... [50 more chars]
+  
+    ''',
+  )
+# ---
+# name: test_main_warns_for_arcade_looper_missing_kit
+  tuple(
+    '',
+    None,
+    '''
+      ─────────────────────────────────── Example ────────────────────────────────────
+        Warning: Arcade sampler "Downstream" on track 1 "Rhythm" is not installed 
+      locally (kit UUID: downstream-kit)
+        <?xml version="1.0" encoding="UTF-8"?><state_info><Looper_Preset><info 
+      name="Downstream" uuid="downstream-kit" product_uuid="honey-product" 
+      version="1.3.0"/></Looper_Preset></state_info>
   
     ''',
   )

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -205,7 +205,7 @@ def test_main_plugins_no_args(
     assert (result.stderr, result.exception, result.stdout) == snapshot
 
 
-def test_main_raw_mode_sections(tmp_path: Path) -> None:
+def test_main_raw_mode_sections(snapshot: SnapshotAssertion, tmp_path: Path) -> None:
     """Test raw mode prints decoded settings within project sections."""
     project_file = tmp_path / "Example.rpp"
     project_file.write_text(
@@ -238,20 +238,12 @@ def test_main_raw_mode_sections(tmp_path: Path) -> None:
 
     result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
 
-    assert result.stderr == ""
-    assert result.exception is None
-    assert result.stdout == (
-        "─────────────────────────────────── Example ────────────────────────────────────\n"
-        "  more\n"
-        "  clap\n"
-        "  dx\n"
-        "  jsf\n"
-        "  lv2\n"
-        "  valid\n"
-    )
+    assert (result.stderr, result.exception, result.stdout) == snapshot
 
 
-def test_main_raw_mode_reassembles_chunked_arcade_state(tmp_path: Path) -> None:
+def test_main_raw_mode_reassembles_chunked_arcade_state(
+    snapshot: SnapshotAssertion, tmp_path: Path
+) -> None:
     """Test raw mode prints one decoded Arcade state instead of chunk fragments."""
     project_file = tmp_path / "Example.rpp"
     long_name = "Downstream " + ("very-long-state " * 20)
@@ -282,16 +274,11 @@ def test_main_raw_mode_reassembles_chunked_arcade_state(tmp_path: Path) -> None:
 
     result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
 
-    assert result.stderr == ""
-    assert result.exception is None
-    assert result.stdout.count("  <?xml version=") == 1
-    assert 'name="Downstream' in result.stdout
-    assert "prefix-bytes" not in result.stdout
-    assert "more chars" in result.stdout
+    assert (result.stderr, result.exception, result.stdout) == snapshot
 
 
 def test_main_warns_for_arcade_hyperion_missing_source(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    snapshot: SnapshotAssertion, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test Arcade Hyperion presets warn when their source content is missing."""
     project_file = tmp_path / "Example.rpp"
@@ -326,19 +313,11 @@ def test_main_warns_for_arcade_hyperion_missing_source(
     )
 
     result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
-
-    assert result.stderr == ""
-    assert result.exception is None
-    assert 'Arcade instrument "Amped Up" on track "Bass note kit"' in result.stdout
-    assert "references" in result.stdout
-    assert "missing source content" in result.stdout
-    assert "missing-source" in result.stdout
-    assert "has an internal" in result.stdout
-    assert '"error" state' in result.stdout
+    assert (result.stderr, result.exception, result.stdout) == snapshot
 
 
 def test_main_does_not_warn_for_arcade_hyperion_installed_source(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    snapshot: SnapshotAssertion, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test Arcade Hyperion presets stay quiet once source content is installed."""
     project_file = tmp_path / "Example.rpp"
@@ -374,13 +353,11 @@ def test_main_does_not_warn_for_arcade_hyperion_installed_source(
 
     result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
 
-    assert result.stderr == ""
-    assert result.exception is None
-    assert "Arcade instrument" not in result.stdout
+    assert (result.stderr, result.exception, result.stdout) == snapshot
 
 
 def test_main_warns_for_arcade_looper_missing_kit(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    snapshot: SnapshotAssertion, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test Arcade looper presets warn when the kit is not installed locally."""
     project_file = tmp_path / "Example.rpp"
@@ -412,16 +389,11 @@ def test_main_warns_for_arcade_looper_missing_kit(
 
     result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
 
-    assert result.stderr == ""
-    assert result.exception is None
-    assert 'Arcade sampler "Downstream" on track "Rhythm"' in result.stdout
-    assert "is not installed" in result.stdout
-    assert "locally" in result.stdout
-    assert "downstream-kit" in result.stdout
+    assert (result.stderr, result.exception, result.stdout) == snapshot
 
 
 def test_main_does_not_warn_for_arcade_looper_installed_kit(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    snapshot: SnapshotAssertion, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test Arcade looper presets stay quiet once the kit exists in local DB."""
     project_file = tmp_path / "Example.rpp"
@@ -453,9 +425,7 @@ def test_main_does_not_warn_for_arcade_looper_installed_kit(
 
     result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
 
-    assert result.stderr == ""
-    assert result.exception is None
-    assert "Arcade sampler" not in result.stdout
+    assert (result.stderr, result.exception, result.stdout) == snapshot
 
 
 def _arcade_au_state_base64(juce_state: bytes) -> str:

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -1,8 +1,11 @@
 """Analyze command tests."""
 
+import base64
+import plistlib
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from click.testing import CliRunner
 from syrupy.assertion import SnapshotAssertion
 
@@ -245,3 +248,61 @@ def test_main_raw_mode_sections(tmp_path: Path) -> None:
         "  lv2\n"
         "  valid\n"
     )
+
+
+def test_main_warns_for_arcade_hyperion_missing_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test Arcade Hyperion presets warn when their source content is missing."""
+    project_file = tmp_path / "Example.rpp"
+    content_root = tmp_path / "Arcade Content"
+    monkeypatch.setenv("ARCADE_CONTENT_ROOT", str(content_root))
+
+    project_file.write_text(
+        f"""<REAPER_PROJECT 0.1 "6.0/x64" 0
+  <TRACK
+    NAME "Bass note kit"
+    <FXCHAIN
+      <AU "AUi: Arcade (Output)" "Output: Arcade" "" 1234<
+        {
+            _arcade_au_state_base64(
+                b'<?xml version="1.0" encoding="UTF-8"?><state_info>'
+                b"<Hyperion_Preset>"
+                b'<info name="Amped Up" uuid="kit-uuid" product_uuid="product-uuid" version="2.0.0"/>'
+                b"<model>"
+                b'<HyperionLoadedSource LoadedSourceUuid="missing-source"/>'
+                b'<HyperionFxBusSettings Name="error"/>'
+                b"</model>"
+                b"</Hyperion_Preset>"
+                b"</state_info>"
+            )
+        }
+      >
+    >
+  >
+>
+"""
+    )
+
+    result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
+
+    assert result.stderr == ""
+    assert result.exception is None
+    assert 'Arcade instrument "Amped Up" on track "Bass note kit"' in result.stdout
+    assert "references" in result.stdout
+    assert "missing source content" in result.stdout
+    assert "missing-source" in result.stdout
+    assert "has an internal" in result.stdout
+    assert '"error" state' in result.stdout
+
+
+def _arcade_au_state_base64(juce_state: bytes) -> str:
+    """Build a minimal Arcade AU state chunk for tests."""
+    outer = plistlib.dumps(
+        {
+            "data": b"",
+            "jucePluginState": b"prefix-bytes" + juce_state + b"trailing-bytes",
+            "name": "Untitled",
+        }
+    )
+    return base64.b64encode(outer).decode("ascii")

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -296,6 +296,85 @@ def test_main_warns_for_arcade_hyperion_missing_source(
     assert '"error" state' in result.stdout
 
 
+def test_main_warns_for_arcade_looper_missing_kit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test Arcade looper presets warn when the kit is not installed locally."""
+    project_file = tmp_path / "Example.rpp"
+    db_path = tmp_path / "arcade.db"
+    monkeypatch.setenv("ARCADE_DB_PATH", str(db_path))
+    _write_arcade_db(db_path, kit_uuids={"some-other-kit"})
+
+    project_file.write_text(
+        f"""<REAPER_PROJECT 0.1 "6.0/x64" 0
+  <TRACK
+    NAME "Rhythm"
+    <FXCHAIN
+      <AU "AUi: Arcade (Output)" "Output: Arcade" "" 1234<
+        {
+            _arcade_au_state_base64(
+                b'<?xml version="1.0" encoding="UTF-8"?><state_info>'
+                b"<Looper_Preset>"
+                b'<info name="Downstream" uuid="downstream-kit" product_uuid="honey-product" version="1.3.0"/>'
+                b"</Looper_Preset>"
+                b"</state_info>"
+            )
+        }
+      >
+    >
+  >
+>
+"""
+    )
+
+    result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
+
+    assert result.stderr == ""
+    assert result.exception is None
+    assert 'Arcade sampler "Downstream" on track "Rhythm"' in result.stdout
+    assert "is not installed" in result.stdout
+    assert "locally" in result.stdout
+    assert "downstream-kit" in result.stdout
+
+
+def test_main_does_not_warn_for_arcade_looper_installed_kit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test Arcade looper presets stay quiet once the kit exists in local DB."""
+    project_file = tmp_path / "Example.rpp"
+    db_path = tmp_path / "arcade.db"
+    monkeypatch.setenv("ARCADE_DB_PATH", str(db_path))
+    _write_arcade_db(db_path, kit_uuids={"downstream-kit"})
+
+    project_file.write_text(
+        f"""<REAPER_PROJECT 0.1 "6.0/x64" 0
+  <TRACK
+    NAME "Rhythm"
+    <FXCHAIN
+      <AU "AUi: Arcade (Output)" "Output: Arcade" "" 1234<
+        {
+            _arcade_au_state_base64(
+                b'<?xml version="1.0" encoding="UTF-8"?><state_info>'
+                b"<Looper_Preset>"
+                b'<info name="Downstream" uuid="downstream-kit" product_uuid="honey-product" version="1.3.0"/>'
+                b"</Looper_Preset>"
+                b"</state_info>"
+            )
+        }
+      >
+    >
+  >
+>
+"""
+    )
+
+    result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
+
+    assert result.stderr == ""
+    assert result.exception is None
+    assert "Arcade sampler" not in result.stdout
+
+
 def _arcade_au_state_base64(juce_state: bytes) -> str:
     """Build a minimal Arcade AU state chunk for tests."""
     outer = plistlib.dumps(
@@ -306,3 +385,14 @@ def _arcade_au_state_base64(juce_state: bytes) -> str:
         }
     )
     return base64.b64encode(outer).decode("ascii")
+
+
+def _write_arcade_db(db_path: Path, kit_uuids: set[str]) -> None:
+    """Create a minimal Arcade metadata DB for tests."""
+    import sqlite3
+
+    with sqlite3.connect(db_path) as con:
+        con.execute("create table kits (uuid text)")
+        con.executemany(
+            "insert into kits (uuid) values (?)", [(uuid,) for uuid in kit_uuids]
+        )

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -2,6 +2,7 @@
 
 import base64
 import plistlib
+from contextlib import closing
 from pathlib import Path
 from unittest import mock
 
@@ -436,7 +437,7 @@ def _write_arcade_db(
     """Create a minimal Arcade metadata DB for tests."""
     import sqlite3
 
-    with sqlite3.connect(db_path) as con:
+    with closing(sqlite3.connect(db_path)) as con:
         con.execute("create table kits (uuid text)")
         con.execute("create table sound_sources (uuid text)")
         con.executemany(
@@ -446,3 +447,4 @@ def _write_arcade_db(
             "insert into sound_sources (uuid) values (?)",
             [(uuid,) for uuid in source_uuids],
         )
+        con.commit()

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -2,6 +2,7 @@
 
 import base64
 import plistlib
+from collections.abc import Iterator
 from contextlib import closing
 from pathlib import Path
 from unittest import mock
@@ -10,8 +11,16 @@ import pytest
 from click.testing import CliRunner
 from syrupy.assertion import SnapshotAssertion
 
-from music.commands.analyze import command
+from music.commands.analyze import process
 from music.commands.analyze.command import main as analyze
+
+
+@pytest.fixture(autouse=True)
+def clear_jsfx_file_cache() -> Iterator[None]:
+    """Isolate cached JSFX path lookups between tests."""
+    process._jsfx_file.cache_clear()
+    yield
+    process._jsfx_file.cache_clear()
 
 
 def test_main_plugins_for_project_file(
@@ -70,9 +79,8 @@ def test_main_plugins_for_project_file(
     (effects_dir / "ReJJ" / "ReEQ").mkdir(parents=True)
     (effects_dir / "utility" / "KanakaMSEncoder1").write_text("desc:Mid/Side Encoder\n")
     (effects_dir / "ReJJ" / "ReEQ" / "ReEQ.jsfx").write_text("desc:ReEQ\n")
-    command._jsfx_file.cache_clear()
 
-    with mock.patch.object(command, "_jsfx_search_paths", return_value=(effects_dir,)):
+    with mock.patch.object(process, "_jsfx_search_paths", return_value=(effects_dir,)):
         result = CliRunner(catch_exceptions=False).invoke(
             analyze, ["--plugins", str(project_file)]
         )
@@ -93,7 +101,8 @@ def test_main_plugins_formats_jsfx_names_with_prefix(
     )
     (effects_dir / "ReJJ" / "ReEQ" / "ReEQ.jsfx").write_text("desc:ReEQ\n")
     project_file.write_text(
-        """<REAPER_PROJECT 0.1 "6.0/x64" 0
+        """\
+<REAPER_PROJECT 0.1 "6.0/x64" 0
   <TRACK
     NAME "Analysis"
     <FXCHAIN
@@ -108,9 +117,8 @@ def test_main_plugins_formats_jsfx_names_with_prefix(
 >
 """
     )
-    command._jsfx_file.cache_clear()
 
-    with mock.patch.object(command, "_jsfx_search_paths", return_value=(effects_dir,)):
+    with mock.patch.object(process, "_jsfx_search_paths", return_value=(effects_dir,)):
         result = CliRunner(catch_exceptions=False).invoke(
             analyze, ["--plugins", str(project_file)]
         )
@@ -129,7 +137,8 @@ def test_main_plugins_reads_legacy_encoded_jsfx_metadata(
         b"desc:Master Limiter\n// Andr\xe9\n"
     )
     project_file.write_text(
-        """<REAPER_PROJECT 0.1 "6.0/x64" 0
+        """\
+<REAPER_PROJECT 0.1 "6.0/x64" 0
   <TRACK
     NAME "Master"
     <FXCHAIN
@@ -141,9 +150,8 @@ def test_main_plugins_reads_legacy_encoded_jsfx_metadata(
 >
 """
     )
-    command._jsfx_file.cache_clear()
 
-    with mock.patch.object(command, "_jsfx_search_paths", return_value=(effects_dir,)):
+    with mock.patch.object(process, "_jsfx_search_paths", return_value=(effects_dir,)):
         result = CliRunner(catch_exceptions=False).invoke(
             analyze, ["--plugins", str(project_file)]
         )
@@ -157,7 +165,8 @@ def test_main_plugins_falls_back_to_clean_jsfx_basename(
     """Test JSFX entries fall back to a cleaned basename when metadata is missing."""
     project_file = tmp_path / "Example.rpp"
     project_file.write_text(
-        """<REAPER_PROJECT 0.1 "6.0/x64" 0
+        """\
+<REAPER_PROJECT 0.1 "6.0/x64" 0
   <TRACK
     <FXCHAIN
       <JS "utility/KanakaMSEncoder1" "" 0 0<
@@ -168,9 +177,8 @@ def test_main_plugins_falls_back_to_clean_jsfx_basename(
 >
 """
     )
-    command._jsfx_file.cache_clear()
 
-    with mock.patch.object(command, "_jsfx_search_paths", return_value=()):
+    with mock.patch.object(process, "_jsfx_search_paths", return_value=()):
         result = CliRunner(catch_exceptions=False).invoke(
             analyze, ["--plugins", str(project_file)]
         )

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -255,8 +255,9 @@ def test_main_warns_for_arcade_hyperion_missing_source(
 ) -> None:
     """Test Arcade Hyperion presets warn when their source content is missing."""
     project_file = tmp_path / "Example.rpp"
-    content_root = tmp_path / "Arcade Content"
-    monkeypatch.setenv("ARCADE_CONTENT_ROOT", str(content_root))
+    db_path = tmp_path / "arcade.db"
+    monkeypatch.setenv("ARCADE_DB_PATH", str(db_path))
+    _write_arcade_db(db_path, kit_uuids=set(), source_uuids=set())
 
     project_file.write_text(
         f"""<REAPER_PROJECT 0.1 "6.0/x64" 0
@@ -296,6 +297,48 @@ def test_main_warns_for_arcade_hyperion_missing_source(
     assert '"error" state' in result.stdout
 
 
+def test_main_does_not_warn_for_arcade_hyperion_installed_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test Arcade Hyperion presets stay quiet once source content is installed."""
+    project_file = tmp_path / "Example.rpp"
+    db_path = tmp_path / "arcade.db"
+    monkeypatch.setenv("ARCADE_DB_PATH", str(db_path))
+    _write_arcade_db(db_path, kit_uuids=set(), source_uuids={"loaded-source"})
+
+    project_file.write_text(
+        f"""<REAPER_PROJECT 0.1 "6.0/x64" 0
+  <TRACK
+    NAME "Bass note kit"
+    <FXCHAIN
+      <AU "AUi: Arcade (Output)" "Output: Arcade" "" 1234<
+        {
+            _arcade_au_state_base64(
+                b'<?xml version="1.0" encoding="UTF-8"?><state_info>'
+                b"<Hyperion_Preset>"
+                b'<info name="Amped Up" uuid="kit-uuid" product_uuid="product-uuid" version="2.0.0"/>'
+                b"<model>"
+                b'<HyperionLoadedSource LoadedSourceUuid="loaded-source"/>'
+                b'<HyperionFxBusSettings Name="error"/>'
+                b"</model>"
+                b"</Hyperion_Preset>"
+                b"</state_info>"
+            )
+        }
+      >
+    >
+  >
+>
+"""
+    )
+
+    result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
+
+    assert result.stderr == ""
+    assert result.exception is None
+    assert "Arcade instrument" not in result.stdout
+
+
 def test_main_warns_for_arcade_looper_missing_kit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -303,7 +346,7 @@ def test_main_warns_for_arcade_looper_missing_kit(
     project_file = tmp_path / "Example.rpp"
     db_path = tmp_path / "arcade.db"
     monkeypatch.setenv("ARCADE_DB_PATH", str(db_path))
-    _write_arcade_db(db_path, kit_uuids={"some-other-kit"})
+    _write_arcade_db(db_path, kit_uuids={"some-other-kit"}, source_uuids=set())
 
     project_file.write_text(
         f"""<REAPER_PROJECT 0.1 "6.0/x64" 0
@@ -344,7 +387,7 @@ def test_main_does_not_warn_for_arcade_looper_installed_kit(
     project_file = tmp_path / "Example.rpp"
     db_path = tmp_path / "arcade.db"
     monkeypatch.setenv("ARCADE_DB_PATH", str(db_path))
-    _write_arcade_db(db_path, kit_uuids={"downstream-kit"})
+    _write_arcade_db(db_path, kit_uuids={"downstream-kit"}, source_uuids=set())
 
     project_file.write_text(
         f"""<REAPER_PROJECT 0.1 "6.0/x64" 0
@@ -387,12 +430,19 @@ def _arcade_au_state_base64(juce_state: bytes) -> str:
     return base64.b64encode(outer).decode("ascii")
 
 
-def _write_arcade_db(db_path: Path, kit_uuids: set[str]) -> None:
+def _write_arcade_db(
+    db_path: Path, kit_uuids: set[str], source_uuids: set[str]
+) -> None:
     """Create a minimal Arcade metadata DB for tests."""
     import sqlite3
 
     with sqlite3.connect(db_path) as con:
         con.execute("create table kits (uuid text)")
+        con.execute("create table sound_sources (uuid text)")
         con.executemany(
             "insert into kits (uuid) values (?)", [(uuid,) for uuid in kit_uuids]
+        )
+        con.executemany(
+            "insert into sound_sources (uuid) values (?)",
+            [(uuid,) for uuid in source_uuids],
         )

--- a/tests/commands/test_analyze.py
+++ b/tests/commands/test_analyze.py
@@ -251,6 +251,45 @@ def test_main_raw_mode_sections(tmp_path: Path) -> None:
     )
 
 
+def test_main_raw_mode_reassembles_chunked_arcade_state(tmp_path: Path) -> None:
+    """Test raw mode prints one decoded Arcade state instead of chunk fragments."""
+    project_file = tmp_path / "Example.rpp"
+    long_name = "Downstream " + ("very-long-state " * 20)
+    looper_info = (
+        f'<info name="{long_name}" uuid="downstream-kit" '
+        'product_uuid="honey-product" version="1.3.0"/>'
+    ).encode()
+    arcade_state = _arcade_au_state_base64(
+        b'<?xml version="1.0" encoding="UTF-8"?><state_info><Looper_Preset>'
+        + looper_info
+        + b"</Looper_Preset></state_info>"
+    )
+    chunked_state = "\n".join(
+        f"        {arcade_state[i : i + 128]}" for i in range(0, len(arcade_state), 128)
+    )
+    project_file.write_text(
+        f"""<REAPER_PROJECT 0.1 "6.0/x64" 0
+  <TRACK
+    <FXCHAIN
+      <AU "AUi: Arcade (Output)" "Output: Arcade" "" 1234<
+{chunked_state}
+      >
+    >
+  >
+>
+"""
+    )
+
+    result = CliRunner(catch_exceptions=False).invoke(analyze, [str(project_file)])
+
+    assert result.stderr == ""
+    assert result.exception is None
+    assert result.stdout.count("  <?xml version=") == 1
+    assert 'name="Downstream' in result.stdout
+    assert "prefix-bytes" not in result.stdout
+    assert "more chars" in result.stdout
+
+
 def test_main_warns_for_arcade_hyperion_missing_source(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
I'm migrating my music projects to a new computer. Reaper warns when plugins are not installed. However, one of my most used plugins, Output Arcade, does _not_ warn when its samples/instrument/kit are not installed. Add warnings for this case.

# Changes

- Decode Output Arcade plugin state
- Warn when Output Arcade content referenced by a project is not installed locally
- Read Arcade installation metadata from the local SQLite database
- Show clearer raw-mode output by reassembling chunked Arcade state and truncating long, infinite loop-seeming previews
- Split long process.py into separate command.py and vendor-specific helper modules

# Test plan

- Add coverage for Arcade projects that warn when referenced content is missing and stay quiet when that content is installed
- Add a raw-mode test that reassembles chunked Arcade state into one decoded setting preview
- Update the raw-mode snapshot coverage for warning output and compact setting previews